### PR TITLE
ci: use GitHub App token for changesets action

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -7,8 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   release-pr:

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -20,6 +20,8 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -14,6 +14,13 @@ jobs:
   release-pr:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
@@ -31,4 +38,4 @@ jobs:
           setupGitUser: true
           createGithubReleases: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary
- Replace `GITHUB_TOKEN` with a GitHub App token (`actions/create-github-app-token`) in the `create-release-pr.yml` workflow
- `GITHUB_TOKEN` does not trigger workflows on commits/PRs it creates (GitHub's recursive workflow prevention), so the changeset release PR never gets CI checks
- Requires `APP_ID` and `APP_PRIVATE_KEY` secrets to be configured

## Test plan
- [ ] Configure GitHub App and add `APP_ID` / `APP_PRIVATE_KEY` secrets
- [ ] Merge a changeset to main and verify the release PR triggers CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)