### PR TITLE
ci: fix Create Release PR workflow by passing App token to checkout

### DIFF
--- a/.changeset/release-dependency-updates.md
+++ b/.changeset/release-dependency-updates.md
@@ -1,5 +1,5 @@
 ---
-"@toiroakr/lines-db": patch
+'@toiroakr/lines-db': patch
 ---
 
 Update runtime dependencies (`commander` to v14.0.3, `@standard-schema/spec` to v1.1.0, `tsx` to v4.21.0) and refresh devDependencies/tooling (migrate from ESLint/Prettier to Oxlint/Oxfmt, TypeScript v6).

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install deps
         uses: ./.github/actions/install-deps


### PR DESCRIPTION
## Summary
- Pass the generated GitHub App token to `actions/checkout` so that `.git/config` gets write-capable credentials instead of the default read-only `GITHUB_TOKEN`.
- Fixes `changesets/action` failing with `git exit code 128` when attempting to push the release branch ([failed run](https://github.com/toiroakr/lines-db/actions/runs/24760599490/job/72443183198)).

## Why
The workflow's top-level `permissions: contents: read` restricts the default `GITHUB_TOKEN` that `actions/checkout` persists into `.git/config`. Even though `changesets/action` receives the write-capable App token via `GITHUB_TOKEN` env, git's stored remote credentials from checkout win for `git push`, causing a permission-denied `exit 128`.

## Test plan
- [ ] Merge this PR
- [ ] Confirm the "Create Release PR" workflow succeeds on the resulting push to `main`
- [ ] Verify an automated `chore: release @toiroakr/lines-db` PR is opened with the pending changeset applied
- [ ] If the workflow does not auto-run (e.g., no new push), trigger it manually via `workflow_dispatch`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toiroakr/lines-db/pull/50" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
