### PR TITLE
chore: exclude CHANGELOG.md from oxfmt

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -3,5 +3,5 @@
   "singleQuote": true,
   "printWidth": 120,
   "sortPackageJson": false,
-  "ignorePatterns": ["pnpm-lock.yaml", "**/*.min.js"]
+  "ignorePatterns": ["pnpm-lock.yaml", "**/*.min.js", "**/CHANGELOG.md"]
 }


### PR DESCRIPTION
## Summary
- Add `**/CHANGELOG.md` to `.oxfmtrc.json` `ignorePatterns` so changesets-generated files no longer fail `pnpm format:check`.

## Why
Changesets-generated CHANGELOGs include blank lines that oxfmt wants to trim, which breaks CI on every release PR (e.g. the current release PR had to be patched manually). Since these files are fully auto-generated, excluding them from formatting is the natural fix.

## Test plan
- [x] `pnpm format:check` passes locally
- [ ] Next release PR's CI passes without manual intervention


---
_Generated by [Claude Code](https://claude.ai/code/session_01VM3UwhynUxpcGVSTHRmTZX)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toiroakr/lines-db/pull/54" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
