### PR TITLE
Configure Renovate to ignore node_modules and bower_components

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", "helpers:pinGitHubActionDigests", ":pinDevDependencies"],
   "labels": ["dependencies"],
+  "ignorePaths": ["**/node_modules/**", "**/bower_components/**"],
   "packageRules": [
     {
       "matchManagers": ["github-actions"],


### PR DESCRIPTION
## Summary
Updated the Renovate configuration to exclude `node_modules` and `bower_components` directories from dependency update checks.

## Changes
- Added `ignorePaths` configuration to the Renovate config with patterns for `node_modules/**` and `bower_components/**`

## Details
This change prevents Renovate from scanning and attempting to update dependencies found within `node_modules` and `bower_components` directories. These are package manager cache/installation directories and should not be directly modified by Renovate, as dependencies should be managed through their respective lock files and package manifests instead.

https://claude.ai/code/session_01FrazubVpUbzyw4xxWHXXeV
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toiroakr/lines-db/pull/56" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
