### PR TITLE
chore(deps): remove @types/glob from extension devDependencies

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -108,7 +108,6 @@
     "test:unit:watch": "vitest"
   },
   "devDependencies": {
-    "@types/glob": "9.0.0",
     "@types/mocha": "10.0.10",
     "@types/node": "24.13.2",
     "@types/vscode": "1.118.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,9 +48,6 @@ importers:
 
   extension:
     devDependencies:
-      '@types/glob':
-        specifier: 9.0.0
-        version: 9.0.0
       '@types/mocha':
         specifier: 10.0.10
         version: 10.0.10
@@ -1337,10 +1334,6 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
-
-  '@types/glob@9.0.0':
-    resolution: {integrity: sha512-00UxlRaIUvYm4R4W9WYkN8/J+kV8fmOQ7okeH6YFtGWFMt3odD45tpG5yA5wnL7HE6lLgjaTW5n14ju2hl2NNA==}
-    deprecated: This is a stub types definition. glob provides its own type definitions, so you do not need this installed.
 
   '@types/jsesc@2.5.1':
     resolution: {integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==}
@@ -4239,10 +4232,6 @@ snapshots:
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
-
-  '@types/glob@9.0.0':
-    dependencies:
-      glob: 13.0.6
 
   '@types/jsesc@2.5.1': {}
 


### PR DESCRIPTION
## Summary

- Remove \`@types/glob\` (v9.0.0) from VS Code extension devDependencies
- \`glob\` v13 ships with bundled TypeScript type definitions, making the separate \`@types/glob\` package redundant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->