### PR TITLE
fix(lib): drop unnecessary valibot peerDependency

### DIFF
--- a/.changeset/remove-valibot-peer-dep.md
+++ b/.changeset/remove-valibot-peer-dep.md
@@ -1,0 +1,5 @@
+---
+'@toiroakr/lines-db': patch
+---
+
+Remove the optional `valibot` peerDependency. The library only relies on the `@standard-schema/spec` interface at runtime and in its public types, so no schema library needs to be declared as a peer dependency.

--- a/lib/package.json
+++ b/lib/package.json
@@ -49,14 +49,6 @@
     "vitest": "4.1.9",
     "zod": "4.4.3"
   },
-  "peerDependencies": {
-    "valibot": ">=1.0.0"
-  },
-  "peerDependenciesMeta": {
-    "valibot": {
-      "optional": true
-    }
-  },
   "dependencies": {
     "@standard-schema/spec": "^1.0.0",
     "amaro": "^1.1.10"


### PR DESCRIPTION
## Summary

- Remove the optional `valibot` peerDependency (and `peerDependenciesMeta`) from `lib/package.json`.
- The library's public API and runtime code only depend on the `@standard-schema/spec` interface (`StandardSchemaV1`), never on valibot's own types. The `import * as v from 'valibot'` seen in `database.test.ts` is a string literal used as a dynamically-loaded test fixture, and `valibot` remains a devDependency so that test can still run.
- No behavior change: consumers can already pass a schema built with any standard-schema-compliant library (valibot, zod, etc.); this only removes a peer dependency declaration that had no corresponding type or runtime coupling.

Adds a patch changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the optional `valibot` peer dependency from the package metadata.
  * Updated the release notes to reflect a patch-level dependency metadata change.
  * Clarified that the library’s public API continues to rely on the standard schema interface without requiring `valibot` at runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->