### PR TITLE
fix: remove js-yaml override that broke changeset version

### DIFF
--- a/.changeset/fix-js-yaml-override.md
+++ b/.changeset/fix-js-yaml-override.md
@@ -1,0 +1,5 @@
+---
+'@toiroakr/lines-db': patch
+---
+
+Remove the `js-yaml: '>=4.2.0'` pnpm override. It forced `@manypkg/get-packages` (via `read-yaml-file@1.1.0`, a transitive dependency of `@changesets/cli`) onto js-yaml 4, whose `yaml.safeLoad` was removed, breaking `pnpm changeset version` and the release workflow. Both js-yaml security advisories the override addressed (quadratic-complexity DoS and prototype pollution in merge handling) are already patched in the 3.x line at 3.15.0, so removing the override lets pnpm resolve that dependency to a safe 3.x release without forcing an incompatible major on affected consumers.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  js-yaml: '>=4.2.0'
   serialize-javascript: '>=7.0.5'
 
 importers:
@@ -1169,6 +1168,9 @@ packages:
     resolution: {integrity: sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==}
     engines: {node: '>=14'}
 
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -1450,6 +1452,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
@@ -1687,6 +1694,10 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-yaml@3.15.0:
+    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+    hasBin: true
 
   js-yaml@4.2.0:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
@@ -2369,6 +2380,9 @@ packages:
 
   spdx-license-ids@3.0.23:
     resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
+
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -3687,6 +3701,10 @@ snapshots:
 
   ansis@4.3.1: {}
 
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
   argparse@2.0.1: {}
 
   array-union@2.1.0: {}
@@ -3977,6 +3995,8 @@ snapshots:
       '@esbuild/win32-ia32': 0.28.1
       '@esbuild/win32-x64': 0.28.1
 
+  esprima@4.0.1: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
@@ -4217,6 +4237,11 @@ snapshots:
       textextensions: 6.11.0
 
   js-tokens@4.0.0: {}
+
+  js-yaml@3.15.0:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
 
   js-yaml@4.2.0:
     dependencies:
@@ -4707,7 +4732,7 @@ snapshots:
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 4.2.0
+      js-yaml: 3.15.0
       pify: 4.0.1
       strip-bom: 3.0.0
 
@@ -4904,6 +4929,8 @@ snapshots:
       spdx-license-ids: 3.0.23
 
   spdx-license-ids@3.0.23: {}
+
+  sprintf-js@1.0.3: {}
 
   stackback@0.0.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,5 +13,4 @@ allowBuilds:
 minimumReleaseAge: 4320
 
 overrides:
-  js-yaml: '>=4.2.0'
   serialize-javascript: '>=7.0.5'


### PR DESCRIPTION
## Summary

- Remove the `js-yaml: '>=4.2.0'` pnpm override from `pnpm-workspace.yaml`.
- The override forced `@manypkg/get-packages` (via `read-yaml-file@1.1.0`, a transitive dependency of `@changesets/cli`) onto js-yaml 4, whose `yaml.safeLoad` API was removed. This crashed `pnpm changeset version` and the "Create Release PR" workflow with `Function yaml.safeLoad is removed in js-yaml 4` (see the failing run on `main` after #133).
- Both advisories the override addressed — the quadratic-complexity DoS and the prototype-pollution issue in merge (`<<`) handling — are already patched on the 3.x line at `3.15.0`, which satisfies `read-yaml-file`'s own `^3.13.1` range. Removing the override lets pnpm resolve that dependency to the safe 3.x release instead of forcing an incompatible major on a consumer that still uses the old API.
- Verified locally: `pnpm audit` reports no known vulnerabilities after the change, and `pnpm changeset version` completes successfully (previously it crashed).

Adds a patch changeset.