### PR TITLE
chore: use version ranges for devDependencies and bump them via renovate

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -10,11 +10,11 @@
     "datadir": "node --import=amaro/transform datadir.ts"
   },
   "devDependencies": {
-    "@types/node": "24.13.3",
-    "amaro": "1.1.11",
-    "typescript": "6.0.3",
-    "valibot": "1.4.2",
-    "zod": "4.4.3"
+    "@types/node": "^24.13.3",
+    "amaro": "^1.1.11",
+    "typescript": "^6.0.3",
+    "valibot": "^1.4.2",
+    "zod": "^4.4.3"
   },
   "dependencies": {
     "@toiroakr/lines-db": "workspace:*"

--- a/extension/package.json
+++ b/extension/package.json
@@ -106,13 +106,13 @@
     "test:watch": "vitest"
   },
   "devDependencies": {
-    "@types/node": "24.13.3",
+    "@types/node": "^24.13.3",
     "@types/vscode": "1.118.0",
-    "@vscode/vsce": "3.9.2",
-    "esbuild": "0.28.1",
-    "prismjs": "1.30.0",
-    "typescript": "6.0.3",
-    "vitest": "4.1.10"
+    "@vscode/vsce": "^3.9.2",
+    "esbuild": "^0.28.1",
+    "prismjs": "^1.30.0",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.10"
   },
   "repository": {
     "type": "git",

--- a/lib/package.json
+++ b/lib/package.json
@@ -44,14 +44,14 @@
   },
   "homepage": "https://github.com/toiroakr/lines-db#readme",
   "devDependencies": {
-    "@types/node": "24.13.3",
+    "@types/node": "^24.13.3",
     "politty": "0.11.6",
-    "publint": "0.3.23",
-    "tsdown": "0.22.14",
-    "type-fest": "5.8.0",
-    "typescript": "6.0.3",
-    "valibot": "1.4.2",
-    "vitest": "4.1.10",
+    "publint": "^0.3.23",
+    "tsdown": "^0.22.14",
+    "type-fest": "^5.8.0",
+    "typescript": "^6.0.3",
+    "valibot": "^1.4.2",
+    "vitest": "^4.1.10",
     "zod": "4.4.3"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -39,10 +39,10 @@
   },
   "homepage": "https://github.com/toiroakr/lines-db#readme",
   "devDependencies": {
-    "@changesets/cli": "2.31.1",
+    "@changesets/cli": "^2.31.1",
     "@toiroakr/lines-db": "workspace:*",
-    "lefthook": "2.1.10",
-    "oxfmt": "0.62.0",
-    "oxlint": "1.77.0"
+    "lefthook": "^2.1.10",
+    "oxfmt": "^0.62.0",
+    "oxlint": "^1.77.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,19 +12,19 @@ importers:
   .:
     devDependencies:
       '@changesets/cli':
-        specifier: 2.31.1
+        specifier: ^2.31.1
         version: 2.31.1(@types/node@24.13.3)
       '@toiroakr/lines-db':
         specifier: workspace:*
         version: link:lib
       lefthook:
-        specifier: 2.1.10
+        specifier: ^2.1.10
         version: 2.1.10
       oxfmt:
-        specifier: 0.62.0
+        specifier: ^0.62.0
         version: 0.62.0
       oxlint:
-        specifier: 1.77.0
+        specifier: ^1.77.0
         version: 1.77.0
 
   examples:
@@ -34,43 +34,43 @@ importers:
         version: link:../lib
     devDependencies:
       '@types/node':
-        specifier: 24.13.3
+        specifier: ^24.13.3
         version: 24.13.3
       amaro:
-        specifier: 1.1.11
+        specifier: ^1.1.11
         version: 1.1.11
       typescript:
-        specifier: 6.0.3
+        specifier: ^6.0.3
         version: 6.0.3
       valibot:
-        specifier: 1.4.2
+        specifier: ^1.4.2
         version: 1.4.2(typescript@6.0.3)
       zod:
-        specifier: 4.4.3
+        specifier: ^4.4.3
         version: 4.4.3
 
   extension:
     devDependencies:
       '@types/node':
-        specifier: 24.13.3
+        specifier: ^24.13.3
         version: 24.13.3
       '@types/vscode':
         specifier: 1.118.0
         version: 1.118.0
       '@vscode/vsce':
-        specifier: 3.9.2
+        specifier: ^3.9.2
         version: 3.9.2(supports-color@7.2.0)
       esbuild:
-        specifier: 0.28.1
+        specifier: ^0.28.1
         version: 0.28.1
       prismjs:
-        specifier: 1.30.0
+        specifier: ^1.30.0
         version: 1.30.0
       typescript:
-        specifier: 6.0.3
+        specifier: ^6.0.3
         version: 6.0.3
       vitest:
-        specifier: 4.1.10
+        specifier: ^4.1.10
         version: 4.1.10(@types/node@24.13.3)(@vitest/ui@4.1.10)(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.9.0))
 
   lib:
@@ -83,28 +83,28 @@ importers:
         version: 1.1.11
     devDependencies:
       '@types/node':
-        specifier: 24.13.3
+        specifier: ^24.13.3
         version: 24.13.3
       politty:
         specifier: 0.11.6
         version: 0.11.6(zod@4.4.3)
       publint:
-        specifier: 0.3.23
+        specifier: ^0.3.23
         version: 0.3.23
       tsdown:
-        specifier: 0.22.14
+        specifier: ^0.22.14
         version: 0.22.14(publint@0.3.23)(typescript@6.0.3)
       type-fest:
-        specifier: 5.8.0
+        specifier: ^5.8.0
         version: 5.8.0
       typescript:
-        specifier: 6.0.3
+        specifier: ^6.0.3
         version: 6.0.3
       valibot:
-        specifier: 1.4.2
+        specifier: ^1.4.2
         version: 1.4.2(typescript@6.0.3)
       vitest:
-        specifier: 4.1.10
+        specifier: ^4.1.10
         version: 4.1.10(@types/node@24.13.3)(@vitest/ui@4.1.10)(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.9.0))
       zod:
         specifier: 4.4.3
@@ -117,19 +117,19 @@ importers:
         version: link:../../lib
     devDependencies:
       '@types/node':
-        specifier: 24.13.3
+        specifier: ^24.13.3
         version: 24.13.3
       '@vitest/ui':
-        specifier: 4.1.10
+        specifier: ^4.1.10
         version: 4.1.10(vitest@4.1.10)
       typescript:
-        specifier: 6.0.3
+        specifier: ^6.0.3
         version: 6.0.3
       valibot:
-        specifier: 1.4.2
+        specifier: ^1.4.2
         version: 1.4.2(typescript@6.0.3)
       vitest:
-        specifier: 4.1.10
+        specifier: ^4.1.10
         version: 4.1.10(@types/node@24.13.3)(@vitest/ui@4.1.10)(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.9.0))
 
 packages:

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": ["config:recommended", "helpers:pinGitHubActionDigests", ":pinDevDependencies"],
   "labels": ["dependencies"],
   "minimumReleaseAge": "3 days",
+  "rangeStrategy": "bump",
   "ignorePaths": ["**/node_modules/**", "**/bower_components/**"],
   "packageRules": [
     {
@@ -23,6 +24,10 @@
       "description": "vsce package fails when @types/vscode is newer than engines.vscode. Disable automated updates so engines.vscode and @types/vscode are always bumped together in a single manual change.",
       "matchPackageNames": ["@types/vscode"],
       "enabled": false
+    },
+    {
+      "matchDepTypes": ["devDependencies"],
+      "rangeStrategy": "bump"
     }
   ]
 }

--- a/tests/unit/package.json
+++ b/tests/unit/package.json
@@ -8,11 +8,11 @@
     "test": "vitest run --typecheck"
   },
   "devDependencies": {
-    "@types/node": "24.13.3",
-    "@vitest/ui": "4.1.10",
-    "typescript": "6.0.3",
-    "valibot": "1.4.2",
-    "vitest": "4.1.10"
+    "@types/node": "^24.13.3",
+    "@vitest/ui": "^4.1.10",
+    "typescript": "^6.0.3",
+    "valibot": "^1.4.2",
+    "vitest": "^4.1.10"
   },
   "dependencies": {
     "@toiroakr/lines-db": "workspace:*"


### PR DESCRIPTION
## Summary

- Convert devDependencies from exact pins to caret ranges across all workspace packages (root, `lib`, `examples`, `extension`, `tests/unit`), except `politty`/`zod` in `lib` (handled separately) and `@types/vscode` in `extension` (its updates are intentionally disabled via an existing renovate rule).
- Set renovate's `rangeStrategy` to `bump` at the top level and add a local `packageRule` forcing `rangeStrategy: bump` for `devDependencies`, since `config:recommended`'s `:pinDevDependencies` preset would otherwise force `rangeStrategy: pin` there.
- Refresh `pnpm-lock.yaml` for the new specifiers. Only the `specifier` fields changed — every resolved `version` is byte-identical, so no dependency actually moved.

`dependencies` were already ranges and are unchanged (aside from the `politty`/`zod` follow-up, tracked separately).

No changeset: this only changes renovate/devDependency configuration, not the published artifact.

Ported from toiroakr/vinfer#2.
