### PR TITLE
chore: auto-create changesets for Renovate PRs

### DIFF
--- a/.github/actions/skip-changeset-check/action.yml
+++ b/.github/actions/skip-changeset-check/action.yml
@@ -1,0 +1,36 @@
+name: Skip changeset check
+description: >-
+  Decides whether an automated pnpm-lock.yaml change needs a changeset, by
+  diffing importer `dependencies` (never `devDependencies`) between a
+  before/after snapshot. devDependencies-only bumps and pnpm-workspace.yaml
+  policy pruning don't affect consumers.
+
+inputs:
+  before-lockfile:
+    description: Path to the pnpm-lock.yaml snapshot captured before the automated change
+    required: true
+  after-lockfile:
+    description: Path to the current (changed) pnpm-lock.yaml
+    required: false
+    default: pnpm-lock.yaml
+
+outputs:
+  has-runtime-changes:
+    description: "'true' if any non-private package's runtime dependencies changed"
+    value: ${{ steps.diff.outputs.has-runtime-changes }}
+  changed-names:
+    description: Newline-separated list of affected package names
+    value: ${{ steps.diff.outputs.changed-names }}
+
+runs:
+  using: composite
+  steps:
+    - id: diff
+      shell: bash
+      env:
+        BEFORE_LOCKFILE: ${{ inputs.before-lockfile }}
+        AFTER_LOCKFILE: ${{ inputs.after-lockfile }}
+      run: |
+        node "${{ github.action_path }}/../../scripts/lockfile-runtime-diff.mjs" \
+          --before "$BEFORE_LOCKFILE" \
+          --after "$AFTER_LOCKFILE"

--- a/.github/scripts/lockfile-runtime-diff.mjs
+++ b/.github/scripts/lockfile-runtime-diff.mjs
@@ -2,9 +2,9 @@
 // Diffs pnpm-lock.yaml's per-importer `dependencies` blocks (never
 // `devDependencies`) between a before/after snapshot, to tell whether an
 // automated lockfile change touched any published package's runtime
-// dependencies. Used to decide whether the `skip-changeset` label applies:
-// devDependencies-only bumps and pnpm-workspace.yaml policy pruning don't
-// affect consumers and don't need a changeset.
+// dependencies. Used to decide whether add-renovate-changeset.yml needs to
+// create a changeset: devDependencies-only bumps and pnpm-workspace.yaml
+// policy pruning don't affect consumers and don't need one.
 
 import { readFileSync, appendFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';

--- a/.github/scripts/lockfile-runtime-diff.mjs
+++ b/.github/scripts/lockfile-runtime-diff.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+// Diffs pnpm-lock.yaml's per-importer `dependencies` blocks (never
+// `devDependencies`) between a before/after snapshot, to tell whether an
+// automated lockfile change touched any published package's runtime
+// dependencies. Used to decide whether the `skip-changeset` label applies:
+// devDependencies-only bumps and pnpm-workspace.yaml policy pruning don't
+// affect consumers and don't need a changeset.
+
+import { readFileSync, appendFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+function parseArgs(argv) {
+  const args = { after: 'pnpm-lock.yaml' };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--before') args.before = argv[++i];
+    else if (argv[i] === '--after') args.after = argv[++i];
+  }
+  if (!args.before) throw new Error('--before <path> is required');
+  return args;
+}
+
+function parseImporters(text) {
+  const lines = text.split('\n');
+  const importersIdx = lines.findIndex((l) => /^importers:\s*$/.test(l));
+  if (importersIdx === -1) return {};
+
+  const importers = {};
+  let currentImporter = null;
+  let currentSection = null;
+  let sectionLines = [];
+
+  const flush = () => {
+    if (currentImporter && currentSection === 'dependencies') {
+      importers[currentImporter] = sectionLines.join('\n');
+    }
+    sectionLines = [];
+  };
+
+  for (let i = importersIdx + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.trim() === '') continue;
+    const indent = line.match(/^ */)[0].length;
+    if (indent === 0) break; // back to top-level key, importers block ended
+
+    if (indent === 2) {
+      flush();
+      currentImporter = line
+        .trim()
+        .replace(/:$/, '')
+        .replace(/^["']|["']$/g, '');
+      currentSection = null;
+      continue;
+    }
+    if (indent === 4) {
+      flush();
+      currentSection = line.trim().replace(/:$/, '');
+      continue;
+    }
+    if (currentSection === 'dependencies') sectionLines.push(line);
+  }
+  flush();
+
+  return importers;
+}
+
+function readPackageMeta(importerPath) {
+  const pkgPath = importerPath === '.' ? 'package.json' : join(importerPath, 'package.json');
+  if (!existsSync(pkgPath)) return null;
+  try {
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+    return { name: pkg.name, private: pkg.private === true };
+  } catch {
+    return null;
+  }
+}
+
+// Packages in the same changeset "fixed" group always release together, so a
+// change to one is reported under the group's first (primary) package name —
+// otherwise a changeset naming e.g. create-sdk alone would fail
+// `changeset version` with a "packages in a fixed group must release
+// together" error.
+function loadFixedGroupNormalizer() {
+  const map = new Map();
+  try {
+    const config = JSON.parse(readFileSync('.changeset/config.json', 'utf8'));
+    for (const group of config.fixed ?? []) {
+      for (const name of group) map.set(name, group[0]);
+    }
+  } catch {
+    // no config.json or no "fixed" groups — normalization is a no-op
+  }
+  return (name) => map.get(name) ?? name;
+}
+
+function main() {
+  const { before, after } = parseArgs(process.argv.slice(2));
+
+  const beforeImporters = parseImporters(readFileSync(before, 'utf8'));
+  const afterImporters = parseImporters(readFileSync(after, 'utf8'));
+
+  const paths = new Set([...Object.keys(beforeImporters), ...Object.keys(afterImporters)]);
+  const normalize = loadFixedGroupNormalizer();
+  const changedNames = new Set();
+
+  for (const importerPath of paths) {
+    const beforeDeps = beforeImporters[importerPath] ?? '';
+    const afterDeps = afterImporters[importerPath] ?? '';
+    if (beforeDeps === afterDeps) continue;
+
+    const meta = readPackageMeta(importerPath);
+    if (!meta || meta.private || !meta.name) continue;
+    changedNames.add(normalize(meta.name));
+  }
+
+  const sortedNames = [...changedNames].sort();
+  const hasRuntimeChanges = sortedNames.length > 0;
+  console.log(
+    hasRuntimeChanges
+      ? `Runtime dependency changes detected in: ${sortedNames.join(', ')}`
+      : 'No runtime dependency changes (devDependencies-only and/or policy-list pruning).',
+  );
+
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (outputFile) {
+    appendFileSync(outputFile, `has-runtime-changes=${hasRuntimeChanges}\n`);
+    appendFileSync(outputFile, `changed-names<<LOCKFILE_DIFF_EOF\n${sortedNames.join('\n')}\nLOCKFILE_DIFF_EOF\n`);
+  }
+}
+
+main();

--- a/.github/workflows/add-renovate-changeset.yml
+++ b/.github/workflows/add-renovate-changeset.yml
@@ -1,0 +1,100 @@
+name: Add changeset for Renovate PR
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  add-changeset:
+    name: Add changeset
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read # checkout the PR head
+
+    # `|` rather than `>-`: actrun's YAML parser chokes on folded scalars here.
+    if: |
+      startsWith(github.event.pull_request.head.ref, 'renovate/') &&
+      github.event.pull_request.user.login == 'renovate[bot]' &&
+      github.event.pull_request.user.type == 'Bot'
+
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Default ref on pull_request events is the merge ref
+          # (refs/pull/N/merge), which is PR head merged with the *current* base
+          # branch tip. That pulls in unrelated base-branch changes whenever main
+          # moves forward while the PR is open, causing false positives. Pin to
+          # the PR head sha so the diff only reflects this PR's own changes.
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Check for existing changeset
+        id: existing
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -eo pipefail
+          FILENAME=".changeset/renovate-${PR_NUMBER}.md"
+          if [ -f "$FILENAME" ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "Changeset $FILENAME already exists; skipping"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Snapshot base lockfile
+        if: steps.existing.outputs.found == 'false'
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -eo pipefail
+          git fetch --no-tags --quiet origin "$BASE_REF"
+          BASE_SHA=$(git merge-base "origin/${BASE_REF}" HEAD)
+          git show "$BASE_SHA:pnpm-lock.yaml" > /tmp/renovate-base-lock.yaml
+
+      - name: Determine changeset requirement
+        if: steps.existing.outputs.found == 'false'
+        id: runtime
+        uses: ./.github/actions/skip-changeset-check
+        with:
+          before-lockfile: /tmp/renovate-base-lock.yaml
+
+      - name: Create changeset file
+        if: steps.existing.outputs.found == 'false' && steps.runtime.outputs.has-runtime-changes == 'true'
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          NAMES: ${{ steps.runtime.outputs.changed-names }}
+        run: |
+          set -eo pipefail
+          FILENAME=".changeset/renovate-${PR_NUMBER}.md"
+          {
+            echo "---"
+            while IFS= read -r name; do
+              [ -z "$name" ] && continue
+              printf '"%s": patch\n' "$name"
+            done <<< "$NAMES"
+            echo "---"
+            echo ""
+            printf '%s\n' "${PR_TITLE}"
+          } > "$FILENAME"
+
+      - name: Commit changeset
+        if: steps.existing.outputs.found == 'false' && steps.runtime.outputs.has-runtime-changes == 'true'
+        uses: suzuki-shunsuke/commit-action@06e3b49d4706498d325d29bd85adc82ecf2f5d8f # v1.0.0
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          commit_message: 'chore: add changeset for renovate'
+          files: |
+            .changeset/renovate-${{ github.event.pull_request.number }}.md
+          fail_on_self_push: false

--- a/.github/workflows/add-renovate-changeset.yml
+++ b/.github/workflows/add-renovate-changeset.yml
@@ -11,18 +11,22 @@ concurrency:
 permissions: {}
 
 jobs:
-  add-changeset:
-    name: Add changeset
+  detect:
+    name: Detect changeset requirement
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: read # checkout the PR head
+      contents: read # checkout the PR head; this job never has secrets
 
     # `|` rather than `>-`: actrun's YAML parser chokes on folded scalars here.
     if: |
       startsWith(github.event.pull_request.head.ref, 'renovate/') &&
       github.event.pull_request.user.login == 'renovate[bot]' &&
       github.event.pull_request.user.type == 'Bot'
+
+    outputs:
+      changed: ${{ steps.runtime.outputs.has-runtime-changes }}
+      content: ${{ steps.content.outputs.content }}
 
     steps:
       - name: Checkout PR head
@@ -68,16 +72,21 @@ jobs:
         with:
           before-lockfile: /tmp/renovate-base-lock.yaml
 
-      - name: Create changeset file
+      - name: Build changeset content
         if: steps.existing.outputs.found == 'false' && steps.runtime.outputs.has-runtime-changes == 'true'
+        id: content
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
           NAMES: ${{ steps.runtime.outputs.changed-names }}
         run: |
           set -eo pipefail
-          FILENAME=".changeset/renovate-${PR_NUMBER}.md"
+          # Random delimiter: PR_TITLE and NAMES flow into this heredoc and are
+          # renovate-generated from dependency/package names, so a fixed
+          # delimiter string could in principle be smuggled in to terminate
+          # the heredoc early and inject extra $GITHUB_OUTPUT lines.
+          DELIM="ghadelim_${RANDOM}${RANDOM}${RANDOM}"
           {
+            echo "content<<$DELIM"
             echo "---"
             while IFS= read -r name; do
               [ -z "$name" ] && continue
@@ -86,10 +95,41 @@ jobs:
             echo "---"
             echo ""
             printf '%s\n' "${PR_TITLE}"
-          } > "$FILENAME"
+            echo "$DELIM"
+          } >> "$GITHUB_OUTPUT"
+
+  commit:
+    name: Commit changeset
+    needs: detect
+    if: needs.detect.outputs.changed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read # checkout only; commit-action pushes via its own app credentials
+
+    steps:
+      # This checkout only gives commit-action a git working tree to add the
+      # new changeset file to and push from. Nothing in this job executes any
+      # code from that tree — the diffing/detection that runs code from the
+      # (renovate-controlled but still PR-supplied) checkout happens entirely
+      # in the `detect` job above, which has no secrets. Keeping that split
+      # means PR-supplied content is never on disk in a job that can see
+      # APP_ID/APP_PRIVATE_KEY while anything actually executes.
+      - name: Checkout PR head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Write changeset file
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          CONTENT: ${{ needs.detect.outputs.content }}
+        run: |
+          set -eo pipefail
+          printf '%s\n' "$CONTENT" > ".changeset/renovate-${PR_NUMBER}.md"
 
       - name: Commit changeset
-        if: steps.existing.outputs.found == 'false' && steps.runtime.outputs.has-runtime-changes == 'true'
         uses: suzuki-shunsuke/commit-action@06e3b49d4706498d325d29bd85adc82ecf2f5d8f # v1.0.0
         with:
           app_id: ${{ secrets.APP_ID }}

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", "helpers:pinGitHubActionDigests", ":pinDevDependencies"],
   "labels": ["dependencies"],
+  "gitIgnoredAuthors": ["271965483+toiroakr-release-bot[bot]@users.noreply.github.com"],
   "minimumReleaseAge": "3 days",
   "ignorePaths": ["**/node_modules/**", "**/bower_components/**"],
   "packageRules": [


### PR DESCRIPTION
## Summary

- Add `.github/workflows/add-renovate-changeset.yml`, which runs on Renovate PRs (branch prefix `renovate/`, author `renovate[bot]`) and generates a changeset when the PR's `pnpm-lock.yaml` changes any importer's runtime dependencies, then commits and pushes it via a GitHub App so the release PR picks it up automatically.
- lines-db is a pnpm monorepo with several importers (`lib`, `examples`, `extension`, `tests/*`), so runtime-dependency detection diffs `pnpm-lock.yaml` per importer (`.github/actions/skip-changeset-check` + `.github/scripts/lockfile-runtime-diff.mjs`) instead of diffing a single `package.json` directly. Private/ignored packages and devDependencies-only bumps are skipped since they don't affect consumers.
- Add the bot's own commit identity to `renovate.json`'s `gitIgnoredAuthors`, otherwise Renovate would treat the bot's changeset commit as a foreign edit and stop updating the branch.

This PR is independent of the devDependency-range PR (#176) — both branch from `main` separately, no ordering dependency.

No changeset: this only adds CI tooling, not published-package changes.

Ported from toiroakr/vinfer#3, with the per-importer lockfile diffing approach ported from tailor-platform/sdk's equivalent workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated changeset generation for qualifying Renovate pull requests.
  * Added runtime dependency change detection to identify affected published packages.
  * Added safeguards to avoid duplicate changesets and handle grouped packages.

* **Chores**
  * Updated release automation settings to recognize the release bot’s commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->