### PR TITLE
fix(lib): stop bundling zod/politty into the CLI, declare as dependencies

### DIFF
--- a/.changeset/fix-cli-deps-unbundle.md
+++ b/.changeset/fix-cli-deps-unbundle.md
@@ -1,0 +1,12 @@
+---
+'@toiroakr/lines-db': patch
+---
+
+Stop bundling `zod` and `politty` into the CLI binary (`bin/cli.mjs`) and declare them as regular
+`dependencies` instead of `devDependencies`. Both are implementation details of the CLI's argument
+parsing (`src/cli.ts`) — the library's public API (`src/index.ts`) never touches them — but bundling
+them baked in a copy that could drift from the `zod` version `politty` itself requires as a peer
+dependency. Installing them as ordinary dependencies keeps a single, consistent `zod` instance.
+
+No functional change for consumers: `npx lines-db` and installed CLI usage behave identically, just
+with a smaller bundled binary and `politty`/`zod` resolved from `node_modules` instead.

--- a/.github/scripts/lockfile-runtime-diff.mjs
+++ b/.github/scripts/lockfile-runtime-diff.mjs
@@ -8,6 +8,7 @@
 
 import { readFileSync, appendFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
 
 function parseArgs(argv) {
   const args = { after: 'pnpm-lock.yaml' };
@@ -122,8 +123,9 @@ function main() {
 
   const outputFile = process.env.GITHUB_OUTPUT;
   if (outputFile) {
+    const delimiter = `LOCKFILE_DIFF_EOF_${randomUUID()}`;
     appendFileSync(outputFile, `has-runtime-changes=${hasRuntimeChanges}\n`);
-    appendFileSync(outputFile, `changed-names<<LOCKFILE_DIFF_EOF\n${sortedNames.join('\n')}\nLOCKFILE_DIFF_EOF\n`);
+    appendFileSync(outputFile, `changed-names<<${delimiter}\n${sortedNames.join('\n')}\n${delimiter}\n`);
   }
 }
 

--- a/lib/package.json
+++ b/lib/package.json
@@ -45,17 +45,17 @@
   "homepage": "https://github.com/toiroakr/lines-db#readme",
   "devDependencies": {
     "@types/node": "24.13.3",
-    "politty": "0.11.6",
     "publint": "0.3.23",
     "tsdown": "0.22.14",
     "type-fest": "5.8.0",
     "typescript": "6.0.3",
     "valibot": "1.4.2",
-    "vitest": "4.1.10",
-    "zod": "4.4.3"
+    "vitest": "4.1.10"
   },
   "dependencies": {
     "@standard-schema/spec": "^1.0.0",
-    "amaro": "^1.1.10"
+    "amaro": "^1.1.10",
+    "politty": "^0.11.6",
+    "zod": "^4.4.3"
   }
 }

--- a/lib/tsdown.config.ts
+++ b/lib/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsdown';
 
 export default defineConfig([
-  // CLI build (ESM only, fully bundled)
+  // CLI build (ESM only)
   {
     entry: ['src/cli.ts'],
     format: ['esm'],
@@ -12,10 +12,6 @@ export default defineConfig([
     outDir: 'bin',
     dts: false,
     treeshake: true,
-    deps: {
-      alwaysBundle: ['zod', 'politty'],
-      onlyBundle: false,
-    },
   },
   // Library build (ESM only)
   {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,13 +81,16 @@ importers:
       amaro:
         specifier: ^1.1.10
         version: 1.1.11
+      politty:
+        specifier: ^0.11.6
+        version: 0.11.6(zod@4.4.3)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/node':
         specifier: 24.13.3
         version: 24.13.3
-      politty:
-        specifier: 0.11.6
-        version: 0.11.6(zod@4.4.3)
       publint:
         specifier: 0.3.23
         version: 0.3.23
@@ -106,9 +109,6 @@ importers:
       vitest:
         specifier: 4.1.10
         version: 4.1.10(@types/node@24.13.3)(@vitest/ui@4.1.10)(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.9.0))
-      zod:
-        specifier: 4.4.3
-        version: 4.4.3
 
   tests/unit:
     dependencies:


### PR DESCRIPTION
## Summary

- Stop bundling `zod` and `politty` into the CLI binary (`bin/cli.mjs`) via tsdown's `deps.alwaysBundle`; both are implementation details of `src/cli.ts` (argument parsing) and are never touched by the library's public API in `src/index.ts`.
- Move both from `devDependencies` to `dependencies` in `lib/package.json`, at ranges compatible with what `politty` itself requires — `politty` declares `"zod": "^4.2.1"` as a required (non-optional) `peerDependency`, so lines-db now satisfies that peer requirement with its own explicit `zod` dependency instead of relying on whatever copy tsdown happened to bundle.
- Remove the `deps: { alwaysBundle: ['zod', 'politty'], onlyBundle: false }` block from the CLI build config in `lib/tsdown.config.ts`.

## Why

Bundling baked a private copy of `zod`/`politty` into the CLI, decoupled from whatever version `politty`'s own `peerDependencies` contract expects. Declaring them as ordinary dependencies keeps a single, consistent `zod` instance and lets pnpm/npm manage the version resolution normally.

## Verification

- `pnpm --filter @toiroakr/lines-db build` — `bin/cli.mjs` now builds to ~79 KB (down from bundling zod+politty in).
- `node lib/bin/cli.mjs --help` runs correctly, resolving `politty`/`zod` from `node_modules`.
- `pnpm --filter @toiroakr/lines-db test` (84 tests) and `pnpm --filter @toiroakr/lines-db-tests-unit test` (254 tests) both pass.
- `pnpm --filter @toiroakr/lines-db publint` — no issues.
- `pnpm-lock.yaml`: `politty`/`zod` moved from `devDependencies` to `dependencies` for the `lib` importer; resolved versions unchanged.

No functional change for consumers: `npx lines-db` and installed CLI usage behave identically.

A patch changeset is included since this changes the package's `dependencies`, which is consumer-visible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI package installation by declaring required runtime dependencies explicitly.
  * CLI behavior remains unchanged while dependencies are resolved from the installed package environment.

* **Chores**
  * Improved automated lockfile comparison reliability by using unique output delimiters for each run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->