### PR TITLE
fix: use single-quoted package name in generated changeset frontmatter

### DIFF
--- a/.github/workflows/add-renovate-changeset.yml
+++ b/.github/workflows/add-renovate-changeset.yml
@@ -90,7 +90,7 @@ jobs:
             echo "---"
             while IFS= read -r name; do
               [ -z "$name" ] && continue
-              printf '"%s": patch\n' "$name"
+              printf "'%s': patch\n" "$name"
             done <<< "$NAMES"
             echo "---"
             echo ""


### PR DESCRIPTION
## Summary

- The \`add-renovate-changeset.yml\` workflow's \`Build changeset content\` step generated the changeset frontmatter with double-quoted package names (\`"@toiroakr/lines-db": patch\`).
- lines-db's \`.oxfmtrc.json\` sets \`singleQuote: true\`, and \`format:check\` (\`oxfmt --check\`) covers \`.changeset/*.md\` (no ignore pattern excludes it).
- This mismatch broke CI on every real Renovate PR that needed a changeset: #180 hit this in practice (\`pnpm format:check\` failed, fixed manually via a Copilot-authored follow-up commit changing the quotes).

## Fix

Changed the \`printf\` in the monorepo lockfile-diff loop to emit single-quoted package names (\`'@toiroakr/lines-db': patch\`), matching both \`@changesets/cli\`'s own default output style and this repo's oxfmt config.

Verified by writing a sample changeset file with the new format and running \`pnpm oxfmt --check\` against it directly — passes clean.