### PR TITLE
ci: fix changesets/action v2 input names in Create Release PR workflow

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -32,12 +32,11 @@ jobs:
         uses: ./.github/actions/install-deps
 
       - name: Create Release Pull Request
-        uses: changesets/action@22ccf9aa43179fe9e27dc62e575971d28cce197c # v2.0.0
+        uses: changesets/action@198f833dd7d863100ea6e28967bc9a9fdefadb0a # v2.1.0
         with:
-          title: 'chore: release @toiroakr/lines-db'
-          commit: 'chore: version packages'
-          version: pnpm changeset version
-          setupGitUser: true
-          createGithubReleases: true
+          pr-title: 'chore: release @toiroakr/lines-db'
+          commit-message: 'chore: version packages'
+          version-script: pnpm changeset version
+          create-github-releases: true
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

- Renovate PR #194 bumped `changesets/action` to v2.0.0 in `.github/workflows/create-release-pr.yml`, but the `with:` block still used the old v1 input names, which v2 silently ignores.
- Updates the `with:` block to the v2 input names: `title` -> `pr-title`, `commit` -> `commit-message`, `version` -> `version-script`, `createGithubReleases` -> `create-github-releases`.
- Removes `setupGitUser`, which no longer exists as an input in v2.
- `@changesets/cli` was already bumped to v3 in #195, satisfying the CLI version v2.0.0 requires.

Fixes the failing "Create Release PR" workflow run (https://github.com/toiroakr/lines-db/actions/runs/31856973631).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release automation workflow to the latest Changesets action version.
  * Refined release pull request titles, commit messages, versioning, and GitHub release creation settings.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->