### PR TITLE
ci: pass GitHub App token via github-token input for changesets/action

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -38,5 +38,4 @@ jobs:
           commit-message: 'chore: version packages'
           version-script: pnpm changeset version
           create-github-releases: true
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

- After #197 fixed the changesets/action v2 input names, the new "Create Release PR" run on main still failed with: `Error: The GITHUB_TOKEN environment variable is set and does not match the "github-token" input.`
- changesets/action v2's `action.yml` defines a `github-token` input (default `${{ github.token }}`) and no longer accepts the token via an `env: GITHUB_TOKEN` variable when it differs from the default token.
- Removes the `env: GITHUB_TOKEN` block and passes the GitHub App token through the `github-token` input instead.