### PR TITLE
ci: disable changesets auto-format to fix Create Release PR crash

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,6 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@toiroakr/lines-db-examples", "@toiroakr/lines-db-tests-unit", "lines-db-vscode"]
+  "ignore": ["@toiroakr/lines-db-examples", "@toiroakr/lines-db-tests-unit", "lines-db-vscode"],
+  "format": false
 }

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -38,5 +38,4 @@ jobs:
           commit-message: 'chore: version packages'
           version-script: pnpm changeset version
           create-github-releases: true
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

- After #198 fixed the github-token input, the "Create Release PR" run on main failed again during `pnpm changeset version`, with `@changesets/format` throwing `Error: Process exited with non-zero status (2)` and the release action reporting `The process '.../bin/pnpm' failed with exit code 1`.
- Root cause: `@changesets/cli` v3 added a new auto-format step that runs the project's detected formatter (oxfmt here, since `.oxfmtrc.json` exists) on the touched `CHANGELOG.md` file after applying the release plan. This repo's `.oxfmtrc.json` explicitly lists `**/CHANGELOG.md` in `ignorePatterns`, so oxfmt is left with zero eligible target files and exits with code 2, which crashes `changeset version`.
- Sets `"format": false` in `.changeset/config.json` to skip that auto-format step. Verified locally that `pnpm changeset version` now completes successfully (bumps `lib/package.json` and `lib/CHANGELOG.md` without error); the version-bump artifacts were discarded after the local verification.