### PR TITLE
chore(deps): migrate from politty to @politty/zod

### DIFF
--- a/.changeset/migrate-politty-to-politty-zod.md
+++ b/.changeset/migrate-politty-to-politty-zod.md
@@ -1,0 +1,5 @@
+---
+'@toiroakr/lines-db': patch
+---
+
+chore(deps): migrate from politty to @politty/zod

--- a/lib/package.json
+++ b/lib/package.json
@@ -53,9 +53,9 @@
     "vitest": "^4.1.10"
   },
   "dependencies": {
+    "@politty/zod": "^0.1.1",
     "@standard-schema/spec": "^1.1.0",
     "amaro": "^1.1.11",
-    "politty": "^0.11.8",
     "zod": "^4.4.3"
   }
 }

--- a/lib/src/cli.ts
+++ b/lib/src/cli.ts
@@ -9,7 +9,7 @@ import { LinesDB } from './database.js';
 import { ErrorFormatter } from './error-formatter.js';
 import type { ValidationError, JsonObject, TableDefs } from './types.js';
 import { z } from 'zod';
-import { arg, defineCommand, runMain } from 'politty';
+import { arg, defineCommand, runMain } from '@politty/zod';
 import { styleText } from 'node:util';
 import { writeFile, stat, readdir } from 'node:fs/promises';
 import { basename, dirname, join } from 'node:path';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,15 +75,15 @@ importers:
 
   lib:
     dependencies:
+      '@politty/zod':
+        specifier: ^0.1.1
+        version: 0.1.1(@clack/prompts@1.7.0)(zod@4.4.3)
       '@standard-schema/spec':
         specifier: ^1.1.0
         version: 1.1.0
       amaro:
         specifier: ^1.1.11
         version: 1.1.11
-      politty:
-        specifier: ^0.11.8
-        version: 0.11.8(@clack/prompts@1.7.0)(zod@4.4.3)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -2142,20 +2142,6 @@ packages:
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
-
-  politty@0.11.8:
-    resolution: {integrity: sha512-WjiPe6zxjFnj3eddtyZrjRZMQS6W5HHcxv1ltee+Lbj/ZCT+EGkytyV0V/5Mz5nHeOhK2QqxIRhvxYdrE+BZpA==}
-    engines: {node: '>=20.12.0 <21.0.0 || >=21.7.0'}
-    hasBin: true
-    peerDependencies:
-      '@clack/prompts': ^0.10.0 || ^0.11.0 || ^1.0.0
-      '@inquirer/prompts': ^8.3.2
-      zod: ^4.2.1
-    peerDependenciesMeta:
-      '@clack/prompts':
-        optional: true
-      '@inquirer/prompts':
-        optional: true
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
@@ -4507,13 +4493,6 @@ snapshots:
   pluralize@2.0.0: {}
 
   pluralize@8.0.0: {}
-
-  politty@0.11.8(@clack/prompts@1.7.0)(zod@4.4.3):
-    dependencies:
-      '@politty/zod': 0.1.1(@clack/prompts@1.7.0)(zod@4.4.3)
-      zod: 4.4.3
-    optionalDependencies:
-      '@clack/prompts': 1.7.0
 
   postcss@8.5.15:
     dependencies:


### PR DESCRIPTION
## Summary

- Replace the `politty` dependency in `lib/package.json` with `@politty/zod`
- Update the import in `lib/src/cli.ts` from `politty` to `@politty/zod`

`politty` is now a compatibility alias that just re-exports `@politty/zod` (`export * from "@politty/zod"` in the upstream repo). Since `lib/src/cli.ts` builds its CLI args with zod schemas (`import { z } from 'zod'`), `@politty/zod` is the correct direct dependency going forward instead of the alias package.

No behavior change: `defineCommand`, `arg`, and `runMain` have an identical API in `@politty/zod`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CLI’s validation tooling to use the latest supported package.
  * Recorded a patch release for the package.
  * No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->