### PR TITLE
fix: revert engines.node requirement to Node >=22.12.0

### DIFF
--- a/.changeset/revert-engines-node-to-22.md
+++ b/.changeset/revert-engines-node-to-22.md
@@ -1,0 +1,7 @@
+---
+'@toiroakr/lines-db': patch
+---
+
+fix: revert engines.node requirement from Node 24 back to Node >=22.12.0
+
+The `engines.node` requirement was unintentionally bumped from `>=22.12.0` to `>=24.19.0` as a side effect of a Renovate update that only intended to pin the CI workflow's Node version, not raise the package's minimum supported Node version. No runtime dependency actually requires Node 24. Consumers can now install and run this package on Node 22.12.0 or later again.

--- a/lib/package.json
+++ b/lib/package.json
@@ -19,7 +19,7 @@
     "CHANGELOG.md"
   ],
   "engines": {
-    "node": ">=24.19.0"
+    "node": ">=22.12.0"
   },
   "scripts": {
     "build": "tsdown",

--- a/renovate.json
+++ b/renovate.json
@@ -27,6 +27,11 @@
       "enabled": false
     },
     {
+      "description": "engines.node must not be auto-bumped just because a CI workflow's actions/setup-node node-version got pinned to a newer version. Requiring a newer Node than runtime dependencies actually need breaks consumers on older Node LTS. Keep it a manual decision.",
+      "matchDepTypes": ["engines"],
+      "enabled": false
+    },
+    {
       "matchDepTypes": ["devDependencies"],
       "rangeStrategy": "bump"
     }


### PR DESCRIPTION
## Summary

- Revert `lib/package.json`'s `engines.node` from `>=24.19.0` back to `>=22.12.0`.
- Add a Renovate `packageRule` disabling automated updates for the `engines` depType, mirroring the existing `@types/vscode` rule.

## Background

This was surfaced by CI failures in the `tailor-platform/sdk` repository's Renovate PR (bumping `@toiroakr/lines-db` to v0.12.3): the `Smoke (hello-world, node, yarn, node22)` job failed because yarn's engine check rejected `@toiroakr/lines-db@0.12.3`'s `engines.node: >=24.19.0` requirement on a Node 22 runner.

The `>=24.19.0` requirement was not intentional. Renovate PR #187 ("chore(deps): update node.js") pinned the CI workflow's `actions/setup-node` `node-version` input from `'24'` to `'24.19.0'`, and in the same commit (`eca59ec`) also bumped `lib/package.json`'s `engines.node` from `>=22.23.2` to `>=24.19.0` — a side effect of that update touching both the CI pin and the package's own engines field together. No runtime dependency needs Node 24: the strictest one, `amaro`, only requires `>=22`, and `0.12.3`/`0.12.4`'s changelog covers only a `politty` → `@politty/zod` dependency migration with no Node 24-specific usage.

The added Renovate rule prevents this class of update from recurring by excluding the `engines` depType from automated changes, so a future CI node-version pin can no longer drag `engines.node` along with it as an unreviewed side effect.

## Notes

- Verified `amaro`, `zod`, `@politty/zod`, and `@standard-schema/spec` all support Node 22.
- `README.md` / `README.ja.md` already document `Node.js 22.12+`, so no doc changes were needed.
- Full local check suite passes: build, test (254 tests), typecheck, lint, format:check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Restored support for Node.js version 22.12.0 and newer.
  * Prevented automatic updates from changing the minimum Node.js version requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->